### PR TITLE
Updated teleop setup

### DIFF
--- a/husky_control/config/twist_mux.yaml
+++ b/husky_control/config/twist_mux.yaml
@@ -4,7 +4,7 @@ topics:
   timeout : 0.5
   priority: 10
 - name    : remote_joy
-  topic   : /mvc/relay/joy_teleop/cmd_vel
+  topic   : /mvc/relay/joy_teleop/cmd_vel_limited
   timeout : 0.5
   priority: 5
 - name    : interactive_marker

--- a/husky_gazebo/launch/husky_empty_world.launch
+++ b/husky_gazebo/launch/husky_empty_world.launch
@@ -39,7 +39,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     <arg name="debug" value="false"/>
   </include>
 
-  <include file="$(find rain_husky_tools)/launch/spawn_husky.launch">
+  <include file="$(find husky_gazebo)/launch/spawn_husky.launch">
     <arg name="laser_enabled" value="$(arg laser_enabled)"/>
     <arg name="realsense_enabled" value="$(arg realsense_enabled)"/>
   </include>

--- a/husky_gazebo/launch/husky_empty_world.launch
+++ b/husky_gazebo/launch/husky_empty_world.launch
@@ -39,7 +39,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     <arg name="debug" value="false"/>
   </include>
 
-  <include file="$(find husky_gazebo)/launch/spawn_husky.launch">
+  <include file="$(find rain_husky_tools)/launch/spawn_husky.launch">
     <arg name="laser_enabled" value="$(arg laser_enabled)"/>
     <arg name="realsense_enabled" value="$(arg realsense_enabled)"/>
   </include>

--- a/husky_gazebo/launch/spawn_husky.launch
+++ b/husky_gazebo/launch/spawn_husky.launch
@@ -69,6 +69,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
         <arg name="realsense_enabled" default="$(arg realsense_enabled)"/>
         <arg name="urdf_extras" value="$(arg urdf_extras)"/>
       </include>
+
+      <remap from="/joy_teleop/cmd_vel" to="/mvc/relay/joy_teleop/cmd_vel"/>
       <include file="$(find husky_control)/launch/teleop.launch">
         <arg name="joystick" value="$(arg joystick)" />
       </include>


### PR DESCRIPTION
This makes two changes to the husky setup

1. The operator joy topic is now the limited version: `  topic   : /mvc/relay/joy_teleop/cmd_vel_limited`
2. The `spawn_husky` launches the joystick teleop with topics that matches our setup.